### PR TITLE
Switch to Node.js env

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,14 +22,6 @@ wf your message here
 
 ## Installation
 
-### 1. Install Node.js
-
-This plugin is written in TypeScript, so you need to install Node.js to use it with Flow Launcher.
-
-Please go to https://nodejs.org/ and download the LTS ("Long Term Support") version of Node.js.
-
-### 2. Install the plugin
-
 You can find this plugin in Flow's Plugin Store (in the app's settings), or by directly running this command in Flow Launcher:
 
 ```

--- a/plugin.json
+++ b/plugin.json
@@ -4,9 +4,9 @@
   "Name": "Workflowy",
   "Description": "Quick save items to Workflowy",
   "Author": "BrunoLM",
-  "Version": "1.0.0",
-  "Language": "executable",
+  "Version": "1.0.1",
+  "Language": "typescript",
   "Website": "https://github.com/brunolm/workflowy-wf",
-  "ExecuteFileName": "run.bat",
+  "ExecuteFileName": "./build/index.js",
   "IcoPath": "Images\\app.png"
 }

--- a/run.bat
+++ b/run.bat
@@ -1,3 +1,0 @@
-@echo off
-SET plugin_dir=%~dp0%
-node %plugin_dir%/build/index.js %*


### PR DESCRIPTION
Hi there, this PR will switch the plugin to use Flow's automatic Node.js environment setup. User will be prompted to install/select Node.js, so manual installation will no longer be required.